### PR TITLE
Fixed README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install -r requirements.txt
 The project runs a PostgreSQL database. Set up the database:
 
 ```
-createdb
+createdb acquisitions
 ./manage.py migrate
 ```
 


### PR DESCRIPTION
Right now, you don't name the database to be created by the createdb
command. This commit adds the name `acquisitions` for the command.