### PR TITLE
Create NDA form for authenticated users

### DIFF
--- a/nda/tests/test_markdown.py
+++ b/nda/tests/test_markdown.py
@@ -4,4 +4,7 @@ from django.template.loader import render_to_string
 
 def test_markdown():
     rendered = render_to_string('nda/nda.html')
-    assert "<h1>Non-Disclosure Agreement</h1>" in rendered
+    # The h1 tag has a tab due to markdown rendering for some reason
+    expected = "<h1>    Non-Disclosure Agreement for TTS Office of "\
+               "Acquisitions</h1>"
+    assert expected in rendered


### PR DESCRIPTION
This adds a NDA that authenticated users can agree to. It then adds the user to the `NDA Signed` group, which the projects app uses to determine permissions.

The NDA content is pulled from Markdown file, rather than a Django HTML template. That decision makes things a little more complicated to render, but will hopefully make the template easier to update by anybody.

Some remaining todos:
- [x] Look into rendering things into the Markdown
- [x] Add actual NDA content
- [x] Consider a model-based approach with a built-in Markdown editor instead of the file-based approach
- [ ] ~Create object-level permissions for IAAs, projects, and buys~
- [x] Make blanket NDA level (with an associated group) able to view details of non-public stuff
- [x] Make higher-level NDA ~with object permissions~ for users who need to interact with the actual data.
- [x] Require admin approval to sign either type of NDA