### PR TITLE
Expanded project and buy pages

### DIFF
--- a/acquisitions/urls.py
+++ b/acquisitions/urls.py
@@ -22,12 +22,16 @@ from django.conf import settings
 from django.conf.urls.static import static
 
 
+api_patterns = projects_urls.api_patterns
+
+
 urlpatterns = [
     url(r'^$', web_views.index),
     url(r'^guides$', web_views.guides),
+    url(r'^api/', include(api_patterns, namespace='api')),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^team/', include(team_urls, namespace='team')),
-    url(r'^projects/', include(projects_urls, namespace='projects')),
+    url(r'^projects/', include(projects_urls.urlpatterns, namespace='projects')),
     url(r'^profile/$', web_views.profile),
     url(r'^profile/refresh_token/$', web_views.refresh_token),
     url(r'^auth/', include('uaa_client.urls', namespace='uaa_client')),

--- a/acquisitions/urls.py
+++ b/acquisitions/urls.py
@@ -22,7 +22,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 
 
-api_patterns = projects_urls.api_patterns
+api_patterns = projects_urls.api_patterns + team_urls.api_patterns
 
 
 urlpatterns = [
@@ -30,7 +30,7 @@ urlpatterns = [
     url(r'^guides$', web_views.guides),
     url(r'^api/', include(api_patterns, namespace='api')),
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^team/', include(team_urls, namespace='team')),
+    url(r'^team/', include(team_urls.urlpatterns, namespace='team')),
     url(r'^projects/', include(projects_urls.urlpatterns, namespace='projects')),
     url(r'^profile/$', web_views.profile),
     url(r'^profile/refresh_token/$', web_views.refresh_token),

--- a/acquisitions/urls.py
+++ b/acquisitions/urls.py
@@ -31,7 +31,14 @@ urlpatterns = [
     url(r'^api/', include(api_patterns, namespace='api')),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^team/', include(team_urls.urlpatterns, namespace='team')),
-    url(r'^projects/', include(projects_urls.urlpatterns, namespace='projects')),
+    url(
+        r'^projects/',
+        include(projects_urls.project_patterns, namespace='projects')
+    ),
+    url(
+        r'^buys/',
+        include(projects_urls.buy_patterns, namespace='buys')
+    ),
     url(r'^profile/$', web_views.profile),
     url(r'^profile/refresh_token/$', web_views.refresh_token),
     url(r'^auth/', include('uaa_client.urls', namespace='uaa_client')),

--- a/projects/models.py
+++ b/projects/models.py
@@ -95,6 +95,9 @@ class Project(models.Model):
         default=True,
     )
 
+    def is_private(self):
+        return not self.public
+
     class Meta:
         permissions = (
             ('view_private', 'Can view non-public projects'),

--- a/projects/models.py
+++ b/projects/models.py
@@ -132,6 +132,9 @@ class Buy(models.Model):
     def __str__(self):
         return self.name
 
+    def is_private(self):
+        return not self.public
+
     def clean(self):
         if (not self.project.public == True) and (self.public == True):
             raise ValidationError({

--- a/projects/templates/projects/buy.html
+++ b/projects/templates/projects/buy.html
@@ -1,0 +1,14 @@
+{% extends "web/base.html" %}
+
+{% block content %}
+<section class="usa-grid">
+  <div class="usa-width-one-full">
+    <h1>{{ buy.name }}</h1>
+    {% if buy.is_private %}<div>This buy is not yet public.</div>{% endif %}
+    <h2>Description</h2>
+    <div id="description">
+      {{ buy.description }}
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/projects/templates/projects/buys.html
+++ b/projects/templates/projects/buys.html
@@ -1,0 +1,53 @@
+{% extends "web/base.html" %}
+
+{% block content %}
+<section class="usa-grid">
+  <div class="usa-width-one-full">
+    <h1>Buys</h1>
+    {% if perms.project.view_private %}<div>Showing: <strong>public</strong> and <strong>non-public</strong> buys</div>{% endif %}
+    <h2>Current</h2>
+    <div id="current">
+
+    </div>
+  </div>
+</section>
+<script type="text/javascript">
+  function createBuy(buy) {
+    // Create a div element with information about the buy
+    let div = document.createElement('div');
+    div.id = 'buy-'+buy.id;
+    let buyName = document.createElement('h3');
+    let buyLink = document.createElement('a');
+    buyLink.href = '/buys/'+buy.id;
+    let nameContent = document.createTextNode(buy.name);
+    buyLink.appendChild(nameContent);
+    buyName.appendChild(buyLink);
+    buyName.className = 'buyName';
+    let buyDescription = document.createElement('div');
+    let descriptionContent = document.createTextNode(buy.description);
+    buyDescription.appendChild(descriptionContent);
+    buyDescription.className = 'buyDescription';
+    div.appendChild(buyName);
+    div.appendChild(buyDescription);
+    return div
+  }
+  const current = document.getElementById('current');
+  const r1 = new XMLHttpRequest();
+  r1.open("GET", "/api/buys/", true);
+  r1.onreadystatechange = function () {
+    if (r1.readyState != 4 || r1.status != 200) return;
+    var jsonResponse = JSON.parse(r1.responseText);
+    if (jsonResponse.length > 0) {
+      for (const buy of jsonResponse) {
+        current.appendChild(createBuy(buy));
+      }
+    } else {
+      let div = document.createElement("div");
+      let content = document.createTextNode("No public buys");
+      div.appendChild(content);
+      current.appendChild(div);
+    }
+  };
+  r1.send();
+</script>
+{% endblock %}

--- a/projects/templates/projects/index.html
+++ b/projects/templates/projects/index.html
@@ -65,7 +65,7 @@
     document.addEventListener("DOMContentLoaded", function(event) {
       let current = document.getElementById('current');
       let r1 = new XMLHttpRequest();
-      r1.open("GET", "/projects/api/projects/", true);
+      r1.open("GET", "/api/projects/", true);
       r1.onreadystatechange = function () {
         if (r1.readyState != 4 || r1.status != 200) return;
         var jsonResponse = JSON.parse(r1.responseText);
@@ -82,7 +82,7 @@
       };
       r1.send();
       let r2 = new XMLHttpRequest();
-      r2.open("GET", "/projects/api/buys/", true);
+      r2.open("GET", "/api/buys/", true);
       r2.onreadystatechange = function () {
         if (r2.readyState != 4 || r2.status != 200) return;
         var jsonResponse = JSON.parse(r2.responseText);

--- a/projects/templates/projects/index.html
+++ b/projects/templates/projects/index.html
@@ -1,99 +1,99 @@
 {% extends "web/base.html" %}
 
 {% block content %}
-  <section class="usa-grid">
-    <div class="usa-width-one-full">
-      <h1>Projects</h1>
-      {% if perms.project.view_private %}<div>Showing: <strong>public</strong> and <strong>non-public</strong> projects</div>{% endif %}
-      <h2>Current</h2>
-      <div id="current">
+<section class="usa-grid">
+  <div class="usa-width-one-full">
+    <h1>Projects</h1>
+    {% if perms.project.view_private %}<div>Showing: <strong>public</strong> and <strong>non-public</strong> projects</div>{% endif %}
+    <h2>Current</h2>
+    <div id="current">
 
-      </div>
     </div>
-  </section>
-  <script type="text/javascript">
-    function createProject(project) {
-      // Create a div element with information about the project
-      let div = document.createElement('div');
-      div.id = 'project-'+project.id;
-      let projectName = document.createElement('h3');
-      let projectLink = document.createElement('a');
-      projectLink.href = '/projects/'+project.id;
-      let nameContent = document.createTextNode(project.name);
-      projectLink.appendChild(nameContent);
-      projectName.appendChild(projectLink);
-      projectName.className = 'projectName';
-      let projectDescription = document.createElement('div');
-      let descriptionContent = document.createTextNode(project.description);
-      projectDescription.appendChild(descriptionContent);
-      projectDescription.className = 'projectDescription';
-      div.appendChild(projectName);
-      div.appendChild(projectDescription);
-      return div
+  </div>
+</section>
+<script type="text/javascript">
+  function createProject(project) {
+    // Create a div element with information about the project
+    let div = document.createElement('div');
+    div.id = 'project-'+project.id;
+    let projectName = document.createElement('h3');
+    let projectLink = document.createElement('a');
+    projectLink.href = '/projects/'+project.id;
+    let nameContent = document.createTextNode(project.name);
+    projectLink.appendChild(nameContent);
+    projectName.appendChild(projectLink);
+    projectName.className = 'projectName';
+    let projectDescription = document.createElement('div');
+    let descriptionContent = document.createTextNode(project.description);
+    projectDescription.appendChild(descriptionContent);
+    projectDescription.className = 'projectDescription';
+    div.appendChild(projectName);
+    div.appendChild(projectDescription);
+    return div
+  }
+  function createBuy(buy) {
+    // Check for project buy wrapper div
+    let wrapper = document.getElementById('project-'+buy.project.id+'-buy-wrapper');
+    let project = document.getElementById('project-'+buy.project.id)
+    if (!wrapper) {
+      wrapper = document.createElement('div');
+      wrapper.id = 'project-'+buy.project.id+'-buy-wrapper';
+      wrapper.className = 'usa-grid';
+      let sidebarWrapper = document.createElement('div');
+      sidebarWrapper.className = 'usa-width-one-sixth';
+      let sidebar = document.createElement('div');
+      let sidebarTitle = document.createElement('h4');
+      let sidebarContent = document.createTextNode('Buys');
+      sidebarTitle.appendChild(sidebarContent);
+      sidebar.appendChild(sidebarTitle);
+      sidebarWrapper.appendChild(sidebar);
+      let main = document.createElement('div');
+      main.className = 'usa-width-five-sixths';
+      wrapper.appendChild(sidebarWrapper);
+      wrapper.appendChild(main);
+      project.appendChild(wrapper);
     }
-    function createBuy(buy) {
-      // Check for project buy wrapper div
-      let wrapper = document.getElementById('project-'+buy.project.id+'-buy-wrapper');
-      let project = document.getElementById('project-'+buy.project.id)
-      if (!wrapper) {
-        wrapper = document.createElement('div');
-        wrapper.id = 'project-'+buy.project.id+'-buy-wrapper';
-        wrapper.className = 'usa-grid';
-        let sidebarWrapper = document.createElement('div');
-        sidebarWrapper.className = 'usa-width-one-sixth';
-        let sidebar = document.createElement('div');
-        let sidebarTitle = document.createElement('h4');
-        let sidebarContent = document.createTextNode('Buys');
-        sidebarTitle.appendChild(sidebarContent);
-        sidebar.appendChild(sidebarTitle);
-        sidebarWrapper.appendChild(sidebar);
-        let main = document.createElement('div');
-        main.className = 'usa-width-five-sixths';
-        wrapper.appendChild(sidebarWrapper);
-        wrapper.appendChild(main);
-        project.appendChild(wrapper);
+    // Create buy div
+    let buyDiv = document.createElement('div');
+    let buyName = document.createElement('h5');
+    let nameContent = document.createTextNode(buy.name);
+    buyName.appendChild(nameContent);
+    let buyDescription = document.createElement('div');
+    let descriptionContent = document.createTextNode(buy.description);
+    buyDescription.appendChild(descriptionContent);
+    buyDiv.appendChild(buyName);
+    buyDiv.appendChild(buyDescription);
+    wrapper.childNodes[1].appendChild(buyDiv);
+  }
+  document.addEventListener("DOMContentLoaded", function(event) {
+    let current = document.getElementById('current');
+    let r1 = new XMLHttpRequest();
+    r1.open("GET", "/api/projects/", true);
+    r1.onreadystatechange = function () {
+      if (r1.readyState != 4 || r1.status != 200) return;
+      var jsonResponse = JSON.parse(r1.responseText);
+      if (jsonResponse.length > 0) {
+        for (const project of jsonResponse) {
+          current.appendChild(createProject(project));
+        }
+      } else {
+        let div = document.createElement("div");
+        let content = document.createTextNode("No public projects");
+        div.appendChild(content);
+        current.appendChild(div);
       }
-      // Create buy div
-      let buyDiv = document.createElement('div');
-      let buyName = document.createElement('h5');
-      let nameContent = document.createTextNode(buy.name);
-      buyName.appendChild(nameContent);
-      let buyDescription = document.createElement('div');
-      let descriptionContent = document.createTextNode(buy.description);
-      buyDescription.appendChild(descriptionContent);
-      buyDiv.appendChild(buyName);
-      buyDiv.appendChild(buyDescription);
-      wrapper.childNodes[1].appendChild(buyDiv);
+    };
+    r1.send();
+    let r2 = new XMLHttpRequest();
+    r2.open("GET", "/api/buys/", true);
+    r2.onreadystatechange = function () {
+      if (r2.readyState != 4 || r2.status != 200) return;
+      var jsonResponse = JSON.parse(r2.responseText);
+      for (const buy of jsonResponse) {
+        createBuy(buy);
+      }
     }
-    document.addEventListener("DOMContentLoaded", function(event) {
-      let current = document.getElementById('current');
-      let r1 = new XMLHttpRequest();
-      r1.open("GET", "/api/projects/", true);
-      r1.onreadystatechange = function () {
-        if (r1.readyState != 4 || r1.status != 200) return;
-        var jsonResponse = JSON.parse(r1.responseText);
-        if (jsonResponse.length > 0) {
-          for (const project of jsonResponse) {
-            current.appendChild(createProject(project));
-          }
-        } else {
-          let div = document.createElement("div");
-          let content = document.createTextNode("No public projects");
-          div.appendChild(content);
-          current.appendChild(div);
-        }
-      };
-      r1.send();
-      let r2 = new XMLHttpRequest();
-      r2.open("GET", "/api/buys/", true);
-      r2.onreadystatechange = function () {
-        if (r2.readyState != 4 || r2.status != 200) return;
-        var jsonResponse = JSON.parse(r2.responseText);
-        for (const buy of jsonResponse) {
-          createBuy(buy);
-        }
-      }
-      r2.send();
-    });
-  </script>
+    r2.send();
+  });
+</script>
 {% endblock %}

--- a/projects/templates/projects/index.html
+++ b/projects/templates/projects/index.html
@@ -13,12 +13,15 @@
   </section>
   <script type="text/javascript">
     function createProject(project) {
-      // Create a div element with information about the teammate
+      // Create a div element with information about the project
       let div = document.createElement('div');
       div.id = 'project-'+project.id;
       let projectName = document.createElement('h3');
+      let projectLink = document.createElement('a');
+      projectLink.href = '/projects/'+project.id;
       let nameContent = document.createTextNode(project.name);
-      projectName.appendChild(nameContent);
+      projectLink.appendChild(nameContent);
+      projectName.appendChild(projectLink);
       projectName.className = 'projectName';
       let projectDescription = document.createElement('div');
       let descriptionContent = document.createTextNode(project.description);

--- a/projects/templates/projects/project.html
+++ b/projects/templates/projects/project.html
@@ -1,0 +1,14 @@
+{% extends "web/base.html" %}
+
+{% block content %}
+<section class="usa-grid">
+  <div class="usa-width-one-full">
+    <h1>{{ project.name }}</h1>
+    {% if project.is_private %}<div>This project is not yet public.</div>{% endif %}
+    <h2>Description</h2>
+    <div id="description">
+      {{ project.description }}
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/projects/templates/projects/projects.html
+++ b/projects/templates/projects/projects.html
@@ -5,6 +5,9 @@
   <div class="usa-width-one-full">
     <h1>Projects</h1>
     {% if perms.project.view_private %}<div>Showing: <strong>public</strong> and <strong>non-public</strong> projects</div>{% endif %}
+    <div class="">
+      A project is an engagement with a client geared towards accomplishing one particular goal, and may include one or more buys.
+    </div>
     <h2>Current</h2>
     <div id="current">
 

--- a/projects/templates/projects/projects.html
+++ b/projects/templates/projects/projects.html
@@ -4,10 +4,10 @@
 <section class="usa-grid">
   <div class="usa-width-one-full">
     <h1>Projects</h1>
-    {% if perms.project.view_private %}<div>Showing: <strong>public</strong> and <strong>non-public</strong> projects</div>{% endif %}
-    <div class="">
-      A project is an engagement with a client geared towards accomplishing one particular goal, and may include one or more buys.
-    </div>
+    {% if perms.project.view_private %}<p>Showing: <strong>public</strong> and <strong>non-public</strong> projects</p>{% endif %}
+    <p class="">
+      A project is an engagement with a client geared towards accomplishing a particular goal, and may include one or more buys.
+    </p>
     <h2>Current</h2>
     <div id="current">
 

--- a/projects/urls.py
+++ b/projects/urls.py
@@ -19,9 +19,14 @@ api_patterns = [
         name='iaa-detail'),
 ]
 
-urlpatterns = [
-    url(r'^$', views.home, name='home'),
-    url(r'(?P<project>\w+)', views.project, name='project')
+project_patterns = [
+    url(r'^$', views.projects, name='projects'),
+    url(r'(?P<project>\w+)', views.project, name='project'),
+]
+
+buy_patterns = [
+    url(r'^$', views.buys, name='buys'),
+    url(r'(?P<buy>\w+)', views.buy, name='buy'),
 ]
 
 api_patterns = format_suffix_patterns(api_patterns)

--- a/projects/urls.py
+++ b/projects/urls.py
@@ -3,21 +3,25 @@ from projects import views
 from rest_framework.urlpatterns import format_suffix_patterns
 
 
-urlpatterns = [
-    url(r'^$', views.home, name='home'),
-    url(r'^api/$', views.api_root),
-    url(r'^api/projects/$', views.ProjectList.as_view(), name='project-list'),
-    url(r'^api/projects/(?P<pk>[0-9]+)$',
+api_patterns = [
+    # url(r'^api/$', views.api_root),
+    url(r'^projects/$', views.ProjectList.as_view(), name='project-list'),
+    url(r'^projects/(?P<pk>[0-9]+)$',
         views.ProjectDetail.as_view(),
         name='project-detail'),
-    url(r'^api/buys/$', views.BuyList.as_view(), name='buy-list'),
-    url(r'^api/buys/(?P<pk>[0-9]+)$',
+    url(r'^buys/$', views.BuyList.as_view(), name='buy-list'),
+    url(r'^buys/(?P<pk>[0-9]+)$',
         views.BuyDetail.as_view(),
         name='buy-detail'),
-    url(r'^api/iaas/$', views.IAAList.as_view(), name='iaa-list'),
-    url(r'^api/iaas/(?P<pk>[0-9]+)$',
+    url(r'^iaas/$', views.IAAList.as_view(), name='iaa-list'),
+    url(r'^iaas/(?P<pk>[0-9]+)$',
         views.IAADetail.as_view(),
-        name='iaa-detail')
+        name='iaa-detail'),
 ]
 
-urlpatterns = format_suffix_patterns(urlpatterns)
+urlpatterns = [
+    url(r'^$', views.home, name='home'),
+    url(r'(?P<project>\w+)', views.project, name='project')
+]
+
+api_patterns = format_suffix_patterns(api_patterns)

--- a/projects/views.py
+++ b/projects/views.py
@@ -15,7 +15,7 @@ from projects.serializers import IAASerializer, ProjectSerializer, BuySerializer
 
 # Create your views here.
 def projects(request):
-    return render(request, "projects/index.html")
+    return render(request, "projects/projects.html")
 
 
 def project(request, project):

--- a/projects/views.py
+++ b/projects/views.py
@@ -14,12 +14,12 @@ from projects.serializers import IAASerializer, ProjectSerializer, BuySerializer
 
 
 # Create your views here.
-def home(request):
+def projects(request):
     return render(request, "projects/index.html")
 
 
 def project(request, project):
-    # Since we only want to show a page if the person exists, this can't
+    # Since we only want to show a page if the project exists, this can't
     # quite be an API-only thing. But most of the page is built via API.
     project = get_object_or_404(Project, id=project)
     if not project.public:
@@ -28,6 +28,20 @@ def project(request, project):
         else:
             raise Http404
     return render(request, "projects/project.html", {"project": project})
+
+
+def buys(request):
+    return render(request, "projects/buys.html")
+
+
+def buy(request, buy):
+    buy = get_object_or_404(Buy, id=buy)
+    if not buy.public:
+        if request.user.has_perm('projects.view_private'):
+            return render(request, "projects/buy.html", {"buy": buy})
+        else:
+            raise Http404
+    return render(request, "projects/buy.html", {"buy": buy})
 
 
 @api_view(['GET'])

--- a/projects/views.py
+++ b/projects/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import render
+from django.shortcuts import get_object_or_404
 from django.http import Http404
 from rest_framework import viewsets
 from rest_framework import status
@@ -15,6 +16,18 @@ from projects.serializers import IAASerializer, ProjectSerializer, BuySerializer
 # Create your views here.
 def home(request):
     return render(request, "projects/index.html")
+
+
+def project(request, project):
+    # Since we only want to show a page if the person exists, this can't
+    # quite be an API-only thing. But most of the page is built via API.
+    project = get_object_or_404(Project, id=project)
+    if not project.public:
+        if request.user.has_perm('projects.view_private'):
+            return render(request, "projects/project.html", {"project": project})
+        else:
+            raise Http404
+    return render(request, "projects/project.html", {"project": project})
 
 
 @api_view(['GET'])

--- a/team/templates/team/index.html
+++ b/team/templates/team/index.html
@@ -44,7 +44,7 @@
     document.addEventListener("DOMContentLoaded", function(event) {
       let team = document.getElementById('team');
       let r = new XMLHttpRequest();
-      r.open("GET", "/team/api/people/", true);
+      r.open("GET", "/api/team/", true);
       r.onreadystatechange = function () {
         if (r.readyState != 4 || r.status != 200) return;
         var jsonResponse = JSON.parse(r.responseText);

--- a/team/urls.py
+++ b/team/urls.py
@@ -2,13 +2,16 @@ from django.conf.urls import include, url
 from team import views
 from rest_framework.urlpatterns import format_suffix_patterns
 
+api_patterns = [
+    url(r'^team/$', views.TeammateList.as_view()),
+    url(r'^team/(?P<pk>[0-9]+)', views.TeammateDetail.as_view()),
+    url(r'^roles/$', views.RoleList.as_view()),
+    url(r'^roles/(?P<pk>[0-9]+)', views.RoleDetail.as_view()),
+]
+
 urlpatterns = [
     url(r'^$', views.home, name='home'),
-    url(r'^api/people/$', views.TeammateList.as_view()),
-    url(r'^api/people/(?P<pk>[0-9]+)', views.TeammateDetail.as_view()),
-    url(r'^api/roles/$', views.RoleList.as_view()),
-    url(r'^api/roles/(?P<pk>[0-9]+)', views.RoleDetail.as_view()),
     url(r'(?P<teammate>\w+)', views.teammate),
 ]
 
-urlpatterns = format_suffix_patterns(urlpatterns)
+api_patterns = format_suffix_patterns(api_patterns)

--- a/uaa_client/templates/uaa_client/logged_out.html
+++ b/uaa_client/templates/uaa_client/logged_out.html
@@ -1,12 +1,14 @@
 {% extends "web/base.html" %}
 
 {% block content %}
-<div class="usa-width-one-full">
-  <h1>Logged out</h1>
+<section class="usa-grid">
+  <div class="usa-width-one-full">
+    <h1>Logged out</h1>
 
-  <div class="alert alert-success">
-    <h3>You have successfully logged out.</h3>
-    <p>Return to the <a href="/">home page</a>.</p>
+    <div class="alert alert-success">
+      <h3>You have successfully logged out.</h3>
+      <p>Return to the <a href="/">home page</a>.</p>
+    </div>
   </div>
-</div>
+</section>
 {% endblock %}

--- a/web/templates/web/includes/header.html
+++ b/web/templates/web/includes/header.html
@@ -67,15 +67,24 @@
           </ul>
         </li>
         <li>
-          <a class="usa-nav-link" href="/projects">
-            <span>Projects</span>
-          </a>
+          <button class="
+          usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="side-nav-2">
+            <span>Our Work</span>
+          </button>
+          <ul id="side-nav-2" class="usa-nav-submenu">
+            <li>
+              <a href="/projects">Projects</a>
+            </li>
+            <li>
+              <a href="/Buys">Buys</a>
+            </li>
+          </ul>
         </li>
         <li>
-          <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-2">
+          <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-3">
             <span>About</span>
           </button>
-          <ul id="sidenav-2" class="usa-nav-submenu">
+          <ul id="sidenav-3" class="usa-nav-submenu">
             <li>
               <a href="/team">Team</a>
             </li>
@@ -88,10 +97,10 @@
           </ul>
         </li>
         <li>
-          <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-3">
+          <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-4">
             <span>Resources</span>
           </button>
-          <ul id="sidenav-3" class="usa-nav-submenu">
+          <ul id="sidenav-4" class="usa-nav-submenu">
             <li>
               <a href="/guides">Guides</a>
             </li>

--- a/web/templates/web/profile.html
+++ b/web/templates/web/profile.html
@@ -1,23 +1,23 @@
 {% extends "web/base.html" %}
 
 {% block content %}
-  <section clas="usa-grid">
-    <div class="usa-width-one-full">
-      <h1>{{ user }}</h1>
-      <div id="api-token">
-        <h2>API Token</h2>
-        {% if user.auth_token %}
-        <div class="">
-          Token: {{ user.auth_token }}
-        </div>
-        <a class="usa-button" href="/profile/refresh_token/">Refresh token</a>
-        {% else %}
-        <div class="">
-          No API Token
-        </div>
-        <a class="usa-button" href="/profile/refresh_token/">Get a token</a>
-        {% endif %}
+<section class="usa-grid">
+  <div class="usa-width-one-full">
+    <h1>{{ user }}</h1>
+    <div id="api-token">
+      <h2>API Token</h2>
+      {% if user.auth_token %}
+      <div class="">
+        Token: {{ user.auth_token }}
       </div>
+      <a class="usa-button" href="/profile/refresh_token/">Refresh token</a>
+      {% else %}
+      <div class="">
+        No API Token
+      </div>
+      <a class="usa-button" href="/profile/refresh_token/">Get a token</a>
+      {% endif %}
     </div>
-  </section>
+  </div>
+</section>
 {% endblock %}


### PR DESCRIPTION
Each project and each buy now gets a (very basic) page, and there's a page with all projects and one with all buys.

This also includes a simplification of the API URL structure, from `/projects/api/projects` to just `/api/projects`.